### PR TITLE
fix: use a default command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2340,9 +2340,9 @@
       "license": "MIT"
     },
     "node_modules/gunshi": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/gunshi/-/gunshi-0.14.0.tgz",
-      "integrity": "sha512-u4UnGoknRKt+SwhipgeBsXWx22IWW33Jj8VSdIhFTWlpNXaeF2gWhZNRF3/PUXHJnbmMRzuWwm8VfDwTKdFjpw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/gunshi/-/gunshi-0.14.3.tgz",
+      "integrity": "sha512-kfzFuDCQudb/AreWK8sfOTrDJOeV3saWslT2N19kAX1Z1s3/Hsv8LpFSnt/iUfXgVTRPKTE8Ze9GgLHSPY2smQ==",
       "license": "MIT",
       "dependencies": {
         "args-tokens": "^0.14.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,18 +1,8 @@
-import {cli, define} from 'gunshi';
+import {cli} from 'gunshi';
 import {publishCommand} from './commands/publish.js';
 
-const subCommands = new Map([['publish', publishCommand]]);
-
-const mainCommand = define({
-  name: 'default',
-  run() {
-    console.log('No command specified. See --help for available commands.');
-  }
-});
-
-await cli(process.argv.slice(2), mainCommand, {
+await cli(process.argv.slice(2), publishCommand, {
   name: 'sourcemap-publisher',
   version: '0.0.1',
-  description: 'Publishes sourcemaps externally',
-  subCommands
+  description: 'Publishes sourcemaps externally'
 });

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -31,7 +31,6 @@ const options = {
 } as const;
 
 export const publishCommand: Command<typeof options> = define({
-  name: 'publish',
   description: 'Publishes sourcemaps externally',
   options,
   async run(ctx) {


### PR DESCRIPTION
By removing the publish command's name, we can make it behave as a default command.