### PR TITLE
fix: mutate source files directly

### DIFF
--- a/src/utils/__snapshots__/sourcemaps.test.ts.snap
+++ b/src/utils/__snapshots__/sourcemaps.test.ts.snap
@@ -3,21 +3,21 @@
 exports[`updateSourceMapUrls > replaces urls with CDN urls 1`] = `
 "
 // This is a test file
-//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map.map"
+//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map"
 `;
 
 exports[`updateSourceMapUrls > replaces urls with CDN urls 2`] = `
 "
 // This is a test file
-//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map.map"
+//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map"
 `;
 
 exports[`updateSourceMapUrls > replaces urls with CDN urls 3`] = `"// x"`;
 
 exports[`updateSourceMapUrls > replaces urls with CDN urls 4`] = `"// x"`;
 
-exports[`updateSourceMapUrls > warns on non-existent sourcemap 1`] = `
+exports[`updateSourceMapUrls > skips on non-existent sourcemap 1`] = `
 "
 // This is a test file
-//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map.map"
+//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map"
 `;


### PR DESCRIPTION
We currently mistakenly mutate the temporary copies of our source files. This is wrong as we should actually mutate the original sources, and use the temp dir only for sourcemap publishing.