### PR TITLE
feat: use globs for files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
-        "gunshi": "^0.14.0"
+        "gunshi": "^0.14.0",
+        "tinyglobby": "^0.2.12"
       },
       "bin": {
         "sourcemap-publisher": "cli.js"
@@ -2890,8 +2890,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3354,6 +3352,22 @@
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
     },
     "node_modules/tinypool": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vitest": "^3.1.1"
   },
   "dependencies": {
-    "fdir": "^6.4.3",
-    "gunshi": "^0.14.0"
+    "gunshi": "^0.14.0",
+    "tinyglobby": "^0.2.12"
   }
 }

--- a/src/utils/__snapshots__/fs.test.ts.snap
+++ b/src/utils/__snapshots__/fs.test.ts.snap
@@ -1,8 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`getSourceFilesFromPaths > should find all js/ts files in the specified paths 1`] = `
-[
-  "<TEMPDIR>/lib/js-file.js",
-  "<TEMPDIR>/lib/nested/js-file.js",
-]
-`;

--- a/src/utils/__snapshots__/sourcemaps.test.ts.snap
+++ b/src/utils/__snapshots__/sourcemaps.test.ts.snap
@@ -1,5 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`extractSourceMap > retrieves sourcemap URL 1`] = `
+{
+  "path": "TEMP_DIR/foo.js.map",
+  "range": [
+    21,
+    31,
+  ],
+  "source": "TEMP_DIR/foo.js",
+  "success": true,
+}
+`;
+
+exports[`extractSourceMaps > extracts sourcemaps from files 1`] = `
+{
+  "path": "TEMP_DIR/foo.js.map",
+  "range": [
+    21,
+    31,
+  ],
+  "source": "TEMP_DIR/foo.js",
+  "success": true,
+}
+`;
+
 exports[`updateSourceMapUrls > replaces urls with CDN urls 1`] = `
 "
 // This is a test file
@@ -9,15 +33,5 @@ exports[`updateSourceMapUrls > replaces urls with CDN urls 1`] = `
 exports[`updateSourceMapUrls > replaces urls with CDN urls 2`] = `
 "
 // This is a test file
-//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map"
-`;
-
-exports[`updateSourceMapUrls > replaces urls with CDN urls 3`] = `"// x"`;
-
-exports[`updateSourceMapUrls > replaces urls with CDN urls 4`] = `"// x"`;
-
-exports[`updateSourceMapUrls > skips on non-existent sourcemap 1`] = `
-"
-// This is a test file
-//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map"
+//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/bar.js.map"
 `;

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -1,10 +1,6 @@
 import {suite, beforeEach, afterEach, test, expect} from 'vitest';
 import {writeFile, rm, mkdtemp, mkdir, stat} from 'node:fs/promises';
-import {
-  copyRelativeFilesToDir,
-  getSourceFilesFromPaths,
-  getTempDir
-} from './fs.js';
+import {copyRelativeFilesToDir, getTempDir} from './fs.js';
 import path from 'node:path';
 import {tmpdir} from 'node:os';
 
@@ -22,29 +18,6 @@ const writeMockFs = async (tempDir: string) => {
     await writeFile(filePath, content);
   }
 };
-
-suite('getSourceFilesFromPaths', () => {
-  let tempDir: string;
-
-  beforeEach(async () => {
-    tempDir = await mkdtemp(path.join(tmpdir(), 'smpub'));
-    await writeMockFs(tempDir);
-  });
-
-  afterEach(async () => {
-    await rm(tempDir, {force: true, recursive: true});
-  });
-
-  test('should find all js/ts files in the specified paths', async () => {
-    const results = await getSourceFilesFromPaths(tempDir, [
-      path.join(tempDir, 'lib/')
-    ]);
-
-    expect(
-      results.map((p) => p.replace(tempDir, '<TEMPDIR>'))
-    ).toMatchSnapshot();
-  });
-});
 
 suite('getTempDir', () => {
   let tempDir: string;

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -1,14 +1,12 @@
 import {suite, beforeEach, afterEach, test, expect} from 'vitest';
 import {writeFile, rm, mkdtemp, mkdir, stat} from 'node:fs/promises';
-import {copyRelativeFilesToDir, getTempDir} from './fs.js';
+import {copyFileToDir, getTempDir} from './fs.js';
 import path from 'node:path';
 import {tmpdir} from 'node:os';
 
 const mockFs: Record<string, string> = {
-  'lib/js-file.js': '// foo',
-  'lib/ts-file.ts': '// foo',
-  'lib/dts-file.d.ts': '// foo',
-  'lib/nested/js-file.js': '// foo'
+  'lib/file.js': '// foo',
+  'lib/file.d.ts': '// foo'
 };
 
 const writeMockFs = async (tempDir: string) => {
@@ -38,7 +36,7 @@ suite('getTempDir', () => {
   });
 });
 
-suite('copyRelativeFilesToDir', () => {
+suite('copyFileToDir', () => {
   let tempDir: string;
   let targetDir: string;
 
@@ -53,27 +51,21 @@ suite('copyRelativeFilesToDir', () => {
     await rm(targetDir, {force: true, recursive: true});
   });
 
-  test('copies files to target directory', async () => {
-    const files = ['lib/js-file.js', 'lib/ts-file.ts'];
-    await copyRelativeFilesToDir(files, tempDir, targetDir);
+  test('copies file to target directory', async () => {
+    const file = path.join(tempDir, 'lib/file.js');
+    await copyFileToDir(file, tempDir, targetDir);
 
     await expect(
-      stat(path.join(targetDir, 'lib/js-file.js'))
-    ).resolves.not.toThrow();
-    await expect(
-      stat(path.join(targetDir, 'lib/ts-file.ts'))
+      stat(path.join(targetDir, 'lib/file.js'))
     ).resolves.not.toThrow();
   });
 
   test('ignores non-existent files', async () => {
-    const files = ['lib/js-file.js', 'lib/non-existent-file.js'];
-    await copyRelativeFilesToDir(files, tempDir, targetDir);
+    const file = path.join(tempDir, 'lib/non-existent.js');
+    await copyFileToDir(file, tempDir, targetDir);
 
     await expect(
-      stat(path.join(targetDir, 'lib/js-file.js'))
-    ).resolves.not.toThrow();
-    await expect(
-      stat(path.join(targetDir, 'lib/non-existent-file.js'))
+      stat(path.join(targetDir, 'lib/non-existent.js'))
     ).rejects.toThrow();
   });
 });

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,24 +1,5 @@
-import {fdir} from 'fdir';
 import path from 'node:path';
 import {mkdir, rm, stat, cp} from 'node:fs/promises';
-
-export async function getSourceFilesFromPaths(
-  cwd: string,
-  paths: string[]
-): Promise<string[]> {
-  const crawler = new fdir();
-  const files = await crawler
-    .withFullPaths()
-    .exclude((_dirName, dirPath) => {
-      return !paths.some((p) => dirPath.startsWith(p));
-    })
-    .filter((file) => {
-      return paths.some((p) => file.startsWith(p)) && file.endsWith('.js');
-    })
-    .crawl(cwd)
-    .withPromise();
-  return files;
-}
 
 export async function getTempDir(cwd: string, name: string): Promise<string> {
   const tempDir = path.join(cwd, name);

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -10,19 +10,23 @@ export async function getTempDir(cwd: string, name: string): Promise<string> {
   return tempDir;
 }
 
-export async function copyRelativeFilesToDir(
-  files: string[],
+export async function copyFileToDir(
+  file: string,
   sourceDir: string,
   targetDir: string
 ): Promise<void> {
-  for (const file of files) {
-    const sourcePath = path.join(sourceDir, file);
-    const targetPath = path.join(targetDir, file);
-    try {
-      await stat(sourcePath);
-      await cp(sourcePath, targetPath, {recursive: true});
-    } catch {
-      continue;
-    }
+  const targetPath = path.join(targetDir, path.relative(sourceDir, file));
+  const dir = path.dirname(targetPath);
+  try {
+    await stat(file);
+  } catch {
+    // Ignore if it doesn't exist, treat this like a "force copy"
+    return;
   }
+  try {
+    await mkdir(dir, {recursive: true});
+  } catch {
+    // ignore if the dir already exists
+  }
+  await cp(file, targetPath, {recursive: true});
 }

--- a/src/utils/package-json.test.ts
+++ b/src/utils/package-json.test.ts
@@ -96,7 +96,7 @@ suite('preparePackageJson', () => {
       },
       scripts: {}
     };
-    tempDir = await mkdtemp('smpub');
+    tempDir = await mkdtemp(path.join(tmpdir(), 'smpub'));
     pkgPath = path.join(tempDir, 'package.json');
     await writeFile(pkgPath, JSON.stringify(pkg));
   });
@@ -106,7 +106,7 @@ suite('preparePackageJson', () => {
   });
 
   test('prepares package correctly', async () => {
-    await preparePackageJson(tempDir, pkgPath, pkg, ['lib']);
+    await preparePackageJson(tempDir, pkgPath, pkg);
 
     const newPkg = await JSON.parse(await readFile(pkgPath, 'utf8'));
 
@@ -114,7 +114,7 @@ suite('preparePackageJson', () => {
       name: 'test-package',
       version: '1.0.0-sourcemaps',
       main: './stub.js',
-      files: ['./stub.js', 'lib/**/*.map'],
+      files: ['./stub.js', './**/*.map'],
       scripts: {}
     });
   });
@@ -122,7 +122,7 @@ suite('preparePackageJson', () => {
   test('handles prerelease versions', async () => {
     pkg.version = '1.0.0-alpha';
 
-    await preparePackageJson(tempDir, pkgPath, pkg, ['lib']);
+    await preparePackageJson(tempDir, pkgPath, pkg);
 
     const newPkg = await JSON.parse(await readFile(pkgPath, 'utf8'));
 

--- a/src/utils/package-json.test.ts
+++ b/src/utils/package-json.test.ts
@@ -62,8 +62,15 @@ suite('readPackageJson', () => {
     }).rejects.toThrow('Invalid `package.json` file: missing version');
   });
 
+  test('throws when package.json file list is missing', async () => {
+    await writeFile(pkgPath, JSON.stringify({name: 'test', version: '1.0.0'}));
+    await expect(async () => {
+      await readPackageJson(pkgPath);
+    }).rejects.toThrow('Invalid `package.json` file: missing files list');
+  });
+
   test('returns valid package.json object', async () => {
-    const pkg = {name: 'test', version: '1.0.0'};
+    const pkg = {name: 'test', version: '1.0.0', files: []};
     await writeFile(pkgPath, JSON.stringify(pkg));
     const result = await readPackageJson(pkgPath);
     expect(result).toEqual(pkg);
@@ -87,9 +94,7 @@ suite('preparePackageJson', () => {
       bin: {
         foo: './lib/cli.js'
       },
-      scripts: {
-        build: 'build'
-      }
+      scripts: {}
     };
     tempDir = await mkdtemp('smpub');
     pkgPath = path.join(tempDir, 'package.json');
@@ -110,9 +115,7 @@ suite('preparePackageJson', () => {
       version: '1.0.0-sourcemaps',
       main: './stub.js',
       files: ['./stub.js', 'lib/**/*.map'],
-      scripts: {
-        build: 'build'
-      }
+      scripts: {}
     });
   });
 

--- a/src/utils/package-json.ts
+++ b/src/utils/package-json.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 export interface PackageJson {
   name: string;
   version: string;
-  files?: string[];
+  files: string[];
   [key: string]: unknown;
 }
 
@@ -25,7 +25,7 @@ export const readPackageJson = async (p: string): Promise<PackageJson> => {
     throw new Error('Could not parse `package.json` file');
   }
 
-  if (typeof obj !== 'object' || obj === null) {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
     throw new Error('Invalid `package.json` file');
   }
 
@@ -35,6 +35,10 @@ export const readPackageJson = async (p: string): Promise<PackageJson> => {
 
   if (typeof obj.version !== 'string') {
     throw new Error('Invalid `package.json` file: missing version');
+  }
+
+  if (!Array.isArray(obj.files)) {
+    throw new Error('Invalid `package.json` file: missing files list');
   }
 
   return obj as PackageJson;
@@ -56,7 +60,8 @@ export async function preparePackageJson(
     ...packageJson,
     files,
     main: './stub.js',
-    version
+    version,
+    scripts: {}
   };
 
   for (const path of paths) {

--- a/src/utils/package-json.ts
+++ b/src/utils/package-json.ts
@@ -49,10 +49,9 @@ const packageJsonKeysToStrip = ['exports', 'bin'];
 export async function preparePackageJson(
   cwd: string,
   packageJsonPath: string,
-  packageJson: PackageJson,
-  paths: string[]
+  packageJson: PackageJson
 ): Promise<PackageJson> {
-  const files: string[] = ['./stub.js'];
+  const files: string[] = ['./stub.js', './**/*.map'];
   const isPreRelease = packageJson.version.includes('-');
   const versionSep = isPreRelease ? '.' : '-';
   const version = `${packageJson.version}${versionSep}sourcemaps`;
@@ -63,10 +62,6 @@ export async function preparePackageJson(
     version,
     scripts: {}
   };
-
-  for (const path of paths) {
-    files.push(`${path}/**/*.map`);
-  }
 
   for (const key of packageJsonKeysToStrip) {
     newPackageJson[key] = undefined;

--- a/src/utils/sourcemaps.test.ts
+++ b/src/utils/sourcemaps.test.ts
@@ -10,7 +10,8 @@ suite('createExternalSourcemapUrl', () => {
     const file = 'foo/bar.js.map';
     const pkg: PackageJson = {
       name: 'test-package',
-      version: '1.0.0-sourcemaps'
+      version: '1.0.0-sourcemaps',
+      files: []
     };
     expect(createExternalSourcemapUrl(file, pkg)).toBe(
       'https://unpkg.com/test-package@1.0.0-sourcemaps/foo/bar.js.map'
@@ -35,7 +36,8 @@ suite('updateSourceMapUrls', () => {
   beforeEach(async () => {
     pkg = {
       name: 'test-package',
-      version: '1.0.0'
+      version: '1.0.0',
+      files: []
     };
 
     tempDir = await mkdtemp(path.join(tmpdir(), 'smpub'));


### PR DESCRIPTION
Instead of relying on the user passing a set of directories to scan, just use tinyglobby against the `files` globs and filter down to `.js`.