### PR TITLE
fix: slice whole source

### DIFF
--- a/src/utils/__snapshots__/sourcemaps.test.ts.snap
+++ b/src/utils/__snapshots__/sourcemaps.test.ts.snap
@@ -4,8 +4,8 @@ exports[`extractSourceMap > retrieves sourcemap URL 1`] = `
 {
   "path": "TEMP_DIR/foo.js.map",
   "range": [
-    21,
-    31,
+    28,
+    38,
   ],
   "source": "TEMP_DIR/foo.js",
   "success": true,
@@ -16,8 +16,8 @@ exports[`extractSourceMaps > extracts sourcemaps from files 1`] = `
 {
   "path": "TEMP_DIR/foo.js.map",
   "range": [
-    21,
-    31,
+    28,
+    38,
   ],
   "source": "TEMP_DIR/foo.js",
   "success": true,

--- a/src/utils/sourcemaps.test.ts
+++ b/src/utils/sourcemaps.test.ts
@@ -225,10 +225,11 @@ suite('extractSourceMap', () => {
   });
 
   test('retrieves sourcemap URL', async () => {
+    const contents = `// foo
+//# sourceMappingURL=foo.js.map`;
     await writeFiles(
       {
-        'foo.js': `// foo
-//# sourceMappingURL=foo.js.map`,
+        'foo.js': contents,
         'foo.js.map': '// foo'
       },
       tempDir
@@ -241,6 +242,7 @@ suite('extractSourceMap', () => {
     result.source = result.source.replace(tempDir, 'TEMP_DIR');
     result.path = result.path.replace(tempDir, 'TEMP_DIR');
     expect(result).toMatchSnapshot();
+    expect(contents.slice(result.range[0], result.range[1])).toBe('foo.js.map');
   });
 });
 

--- a/src/utils/sourcemaps.ts
+++ b/src/utils/sourcemaps.ts
@@ -70,10 +70,8 @@ export async function extractSourceMap(
     return {source, success: false, reason: 'could not load source file'};
   }
 
-  const trimmedContents = contents.trim();
-  const lastLine = trimmedContents.slice(trimmedContents.lastIndexOf('\n') + 1);
-  const sourcemapPattern = /^\/\/# sourceMappingURL=(.+)/d;
-  const sourcemapMatch = lastLine.match(sourcemapPattern);
+  const sourcemapPattern = /\/\/# sourceMappingURL=(\S+)\s*$/d;
+  const sourcemapMatch = contents.match(sourcemapPattern);
 
   if (!sourcemapMatch || !sourcemapMatch.indices) {
     return {source, success: false, reason: 'no sourcemap found'};


### PR DESCRIPTION
We currently match against the last line, so our indices are a mess.

This changes to matching against the whole file so our indices will be correct, and makes ignoring trailing whitespace easier.