### PR TITLE
fix: switch to jsdelivr

### DIFF
--- a/src/utils/__snapshots__/sourcemaps.test.ts.snap
+++ b/src/utils/__snapshots__/sourcemaps.test.ts.snap
@@ -27,11 +27,11 @@ exports[`extractSourceMaps > extracts sourcemaps from files 1`] = `
 exports[`updateSourceMapUrls > replaces urls with CDN urls 1`] = `
 "
 // This is a test file
-//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/foo.js.map"
+//# sourceMappingURL=https://cdn.jsdelivr.net/npm/test-package@1.0.0/foo.js.map"
 `;
 
 exports[`updateSourceMapUrls > replaces urls with CDN urls 2`] = `
 "
 // This is a test file
-//# sourceMappingURL=https://unpkg.com/test-package@1.0.0/bar.js.map"
+//# sourceMappingURL=https://cdn.jsdelivr.net/npm/test-package@1.0.0/bar.js.map"
 `;

--- a/src/utils/sourcemaps.test.ts
+++ b/src/utils/sourcemaps.test.ts
@@ -19,7 +19,7 @@ suite('createExternalSourcemapUrl', () => {
       files: []
     };
     expect(createExternalSourcemapUrl(file, pkg)).toBe(
-      'https://unpkg.com/test-package@1.0.0-sourcemaps/foo/bar.js.map'
+      'https://cdn.jsdelivr.net/npm/test-package@1.0.0-sourcemaps/foo/bar.js.map'
     );
   });
 });

--- a/src/utils/sourcemaps.ts
+++ b/src/utils/sourcemaps.ts
@@ -6,7 +6,7 @@ export function createExternalSourcemapUrl(
   p: string,
   packageJson: PackageJson
 ): string {
-  return `https://unpkg.com/${packageJson.name}@${packageJson.version}/${p}`;
+  return `https://cdn.jsdelivr.net/npm/${packageJson.name}@${packageJson.version}/${p}`;
 }
 
 export async function updateSourceMapUrls(


### PR DESCRIPTION
They have proper CORS headers and content types, so seems a better choice.